### PR TITLE
Fix Business Card API URL Pattern

### DIFF
--- a/src/lib/getCardData.ts
+++ b/src/lib/getCardData.ts
@@ -19,9 +19,7 @@ export async function getCardData(
     redirect("https://patchbay.xyz");
   }
 
-  const url = `${process.env.NEXT_PUBLIC_PATCHBAY_API_URL}/api/v1/card/public/${custom_endpoint}/${hash}`;
-
-  // Type guard for environment variable
+  // Type guard for environment variable - CHECK BEFORE URL CONSTRUCTION
   if (!process.env.NEXT_PUBLIC_PATCHBAY_API_URL) {
     console.error(
       "NEXT_PUBLIC_PATCHBAY_API_URL environment variable is not set"
@@ -29,9 +27,12 @@ export async function getCardData(
     redirect("https://patchbay.xyz");
   }
 
+  const url = `${process.env.NEXT_PUBLIC_PATCHBAY_API_URL}/api/v1/card/public/${hash}/${custom_endpoint}`;
+
   const res = await fetch(url);
   if (!res.ok) {
     console.error(`API request failed with status: ${res.status}`);
+    console.error(`Failed URL: ${url}`);
     redirect("https://patchbay.xyz");
   }
 


### PR DESCRIPTION
## 🐛 Problem

The application was getting 404 errors when calling the backend API because the URL pattern in `getCardData.ts` was incorrect. The frontend was constructing URLs with the wrong parameter order.

### Error Details
```
API request failed with status: 404
Failed URL: https://api.example.com/api/v1/card/public/custom-endpoint/hash-value
```

## 🔍 Root Cause Analysis

The `getCardData` function was constructing URLs with the wrong parameter order:

**❌ Incorrect URL Pattern:**
```
/api/v1/card/public/{custom_endpoint}/{hash}
```

**✅ Correct URL Pattern:**
```
/api/v1/card/public/{hash}/{custom_endpoint}
```

The backend API expects the `hash` parameter first, then the `custom_endpoint` parameter.

## ✅ Solution

### 1. Fixed URL Construction Order
Changed the URL construction in `getCardData.ts` to match the backend's expected pattern:

```typescript
// Before (incorrect)
const url = `${process.env.NEXT_PUBLIC_PATCHBAY_API_URL}/api/v1/card/public/${custom_endpoint}/${hash}`;

// After (correct)
const url = `${process.env.NEXT_PUBLIC_PATCHBAY_API_URL}/api/v1/card/public/${hash}/${custom_endpoint}`;
```

### 2. Improved Error Handling Order
Also fixed the order of operations to check the environment variable before URL construction:

```typescript
// Type guard for environment variable - CHECK BEFORE URL CONSTRUCTION
if (!process.env.NEXT_PUBLIC_PATCHBAY_API_URL) {
  console.error("NEXT_PUBLIC_PATCHBAY_API_URL environment variable is not set");
  redirect("https://patchbay.xyz");
}

const url = `${process.env.NEXT_PUBLIC_PATCHBAY_API_URL}/api/v1/card/public/${hash}/${custom_endpoint}`;
```

This prevents constructing URLs with `undefined` as the base URL.
